### PR TITLE
Bump v3io/scaler to 0.4.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@
 #
 SCALER_TAG ?= unstable
 SCALER_REPOSITORY ?= iguazio/
-V3IO_SCALER_TAG ?= v0.4.4
+V3IO_SCALER_TAG ?= v0.4.5
 GOPATH ?= $(shell go env GOPATH)
 OS_NAME = $(shell uname)
 


### PR DESCRIPTION
to include https://github.com/v3io/scaler/releases/tag/v0.4.5 fix