### PR TITLE
[ResourceScaler] Fix app resource scaler

### DIFF
--- a/pkg/resourcescaler/resourcescaler.go
+++ b/pkg/resourcescaler/resourcescaler.go
@@ -67,7 +67,10 @@ func New(logger logger.Logger,
 // SetScale scales a service
 // Deprecated: use SetScaleCtx instead
 func (s *AppResourceScaler) SetScale(resources []scalertypes.Resource, scale int) error {
-	return s.SetScaleCtx(context.Background(), resources, scale)
+	setScaleContext, cancelFunc := context.WithTimeout(context.Background(), 15*time.Minute)
+	defer cancelFunc()
+
+	return s.SetScaleCtx(setScaleContext, resources, scale)
 }
 
 // SetScaleCtx scales a service
@@ -306,48 +309,38 @@ func (s *AppResourceScaler) patchIguazioTenantAppServiceSets(ctx context.Context
 
 func (s *AppResourceScaler) waitForNoProvisioningInProcess(ctx context.Context) error {
 	s.logger.DebugWithCtx(ctx, "Waiting for IguazioTenantAppServiceSet to finish provisioning")
-	timeout := time.After(5 * time.Minute)
-	tick := time.NewTimer(10 * time.Second)
-	defer tick.Stop()
 	for {
-		_, _, state, err := s.getIguazioTenantAppServiceSets(ctx)
-		if err != nil {
-			return errors.Wrap(err, "Failed to get iguazio tenant app service sets")
-		}
-
-		if state == "ready" || state == "error" {
-			s.logger.DebugWithCtx(ctx, "IguazioTenantAppServiceSet finished provisioning")
-			return nil
-		}
-
-		s.logger.DebugWithCtx(ctx, "IguazioTenantAppServiceSet is still provisioning", "state", state)
-
 		select {
 		case <-ctx.Done():
-			return errors.New("Context was cancelled")
-		case <-timeout:
-			return errors.New("Timed out waiting for IguazioTenantAppServiceSet to finish provisioning")
-		case <-tick.C:
-			continue
+			return ctx.Err()
+
+		case <-time.After(10 * time.Second):
+			_, _, state, err := s.getIguazioTenantAppServiceSets(ctx)
+			if err != nil {
+				return errors.Wrap(err, "Failed to get iguazio tenant app service sets")
+			}
+
+			if state == "ready" || state == "error" {
+				s.logger.DebugWithCtx(ctx, "IguazioTenantAppServiceSet finished provisioning")
+				return nil
+			}
+
+			s.logger.DebugWithCtx(ctx, "IguazioTenantAppServiceSet is still provisioning", "state", state)
 		}
+
 	}
 }
 
 func (s *AppResourceScaler) waitForServicesState(ctx context.Context, serviceNames []string, desiredState string) error {
 	s.logger.DebugWithCtx(ctx,
-		"Waiting for services to reach desired state",
+		"Waiting for services to reach desired state - Roei",
 		"serviceNames", serviceNames,
 		"desiredState", desiredState)
-	timeout := time.After(10 * time.Minute)
-	tick := time.NewTicker(5 * time.Second)
-	defer tick.Stop()
 	for {
 		select {
 		case <-ctx.Done():
-			return errors.New("Context was cancelled")
-		case <-timeout:
-			return errors.New("Timed out waiting for services to reach desired state")
-		case <-tick.C:
+			return ctx.Err()
+		case <-time.After(5 * time.Second):
 			servicesToCheck := append([]string(nil), serviceNames...)
 			_, statusServicesMap, _, err := s.getIguazioTenantAppServiceSets(ctx)
 			if err != nil {

--- a/pkg/resourcescaler/resourcescaler.go
+++ b/pkg/resourcescaler/resourcescaler.go
@@ -333,7 +333,7 @@ func (s *AppResourceScaler) waitForNoProvisioningInProcess(ctx context.Context) 
 
 func (s *AppResourceScaler) waitForServicesState(ctx context.Context, serviceNames []string, desiredState string) error {
 	s.logger.DebugWithCtx(ctx,
-		"Waiting for services to reach desired state - Roei",
+		"Waiting for services to reach desired state",
 		"serviceNames", serviceNames,
 		"desiredState", desiredState)
 	for {


### PR DESCRIPTION
Fixing bug where we try to write on closed channel on resource start:
<img width="1703" alt="image" src="https://github.com/v3io/scaler/assets/40743125/ef472d8a-3bf8-41e1-affd-e72c46a5eaaa">

After fix:
<img width="1724" alt="image" src="https://github.com/v3io/scaler/assets/40743125/439c06bc-3a2c-4810-8b45-5602b840001e">

Fixed it by moving the logic of cancellation timeout from [app-resource-scaler](https://github.com/v3io/app-resource-scaler/pull/31) to [scaler](https://github.com/v3io/scaler/pull/64)

https://github.com/v3io/scaler/pull/64
https://iguazio.atlassian.net/browse/IG-22367
