### PR TITLE
[ResourceScaler] Wait 30 seconds before scaling to / from zero

### DIFF
--- a/pkg/resourcescaler/resourcescaler.go
+++ b/pkg/resourcescaler/resourcescaler.go
@@ -309,23 +309,48 @@ func (s *AppResourceScaler) patchIguazioTenantAppServiceSets(ctx context.Context
 
 func (s *AppResourceScaler) waitForNoProvisioningInProcess(ctx context.Context) error {
 	s.logger.DebugWithCtx(ctx, "Waiting for IguazioTenantAppServiceSet to finish provisioning")
+
+	finiteStateDiscoveryTimeout := 30 * time.Second
+
+	var finiteStateDiscoveryTime *time.Time
 	for {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
 
-		case <-time.After(10 * time.Second):
+		case <-time.After(1 * time.Second):
 			_, _, state, err := s.getIguazioTenantAppServiceSets(ctx)
 			if err != nil {
 				return errors.Wrap(err, "Failed to get iguazio tenant app service sets")
 			}
 
 			if state == "ready" || state == "error" {
-				s.logger.DebugWithCtx(ctx, "IguazioTenantAppServiceSet finished provisioning")
-				return nil
+				if finiteStateDiscoveryTime == nil {
+					now := time.Now()
+					finiteStateDiscoveryTime = &now
+					s.logger.DebugWithCtx(ctx, "IguazioTenantAppServiceSet finished provisioning")
+				}
+			} else {
+
+				// reset the time if the state is not stable
+				finiteStateDiscoveryTime = nil
 			}
 
-			s.logger.DebugWithCtx(ctx, "IguazioTenantAppServiceSet is still provisioning", "state", state)
+			if finiteStateDiscoveryTime != nil {
+
+				// it has been finite for finiteStateDiscoveryTimeout amount of time
+				// we can safely assume that other services waiting for app services to be ready
+				// captured the state change. now it would be our turn
+				timeSince := time.Since(*finiteStateDiscoveryTime)
+				if timeSince >= finiteStateDiscoveryTimeout {
+					s.logger.DebugWithCtx(ctx, "IguazioTenantAppServiceSet state is stabled")
+					return nil
+
+				}
+				s.logger.DebugWithCtx(ctx, "IguazioTenantAppServiceSet waiting for the state to be stable", "state", state, "timeSince", timeSince)
+			} else {
+				s.logger.DebugWithCtx(ctx, "IguazioTenantAppServiceSet is still provisioning", "state", state)
+			}
 		}
 
 	}

--- a/pkg/resourcescaler/resourcescaler.go
+++ b/pkg/resourcescaler/resourcescaler.go
@@ -322,7 +322,7 @@ func (s *AppResourceScaler) waitForNoProvisioningInProcess(ctx context.Context) 
 			s.logger.DebugWithCtx(ctx, "Checking the state of the Iguazio tenant app service sets")
 			_, _, state, err := s.getIguazioTenantAppServiceSets(ctx)
 			if err != nil {
-				s.logger.ErrorWithCtx(ctx, "Failed to get iguazio tenant app service sets")
+				s.logger.WarnWithCtx(ctx, "Failed to get iguazio tenant app service sets", "err", err)
 				continue
 			}
 
@@ -336,7 +336,10 @@ func (s *AppResourceScaler) waitForNoProvisioningInProcess(ctx context.Context) 
 
 				// reset the time if the state is not stable
 				if finiteStateDiscoveryTime != nil {
-					s.logger.DebugWithCtx(ctx, "IguazioTenantAppServiceSet is provisioning again, resetting discovery time", "state", state, "finiteStateDiscoveryTime", finiteStateDiscoveryTime)
+					s.logger.DebugWithCtx(ctx, "IguazioTenantAppServiceSet is provisioning again, "+
+						"resetting discovery time",
+						"state", state,
+						"finiteStateDiscoveryTime", finiteStateDiscoveryTime)
 				}
 				finiteStateDiscoveryTime = nil
 			}
@@ -352,9 +355,12 @@ func (s *AppResourceScaler) waitForNoProvisioningInProcess(ctx context.Context) 
 					return nil
 
 				}
-				s.logger.DebugWithCtx(ctx, "IguazioTenantAppServiceSet waiting for the state to be stable", "state", state, "timeSince", timeSince)
+				s.logger.DebugWithCtx(ctx, "IguazioTenantAppServiceSet waiting for the state to be stable",
+					"state", state,
+					"timeSince", timeSince)
 			} else {
-				s.logger.DebugWithCtx(ctx, "IguazioTenantAppServiceSet is still provisioning", "state", state)
+				s.logger.DebugWithCtx(ctx, "IguazioTenantAppServiceSet is still provisioning",
+					"state", state)
 			}
 		}
 

--- a/pkg/resourcescaler/resourcescaler.go
+++ b/pkg/resourcescaler/resourcescaler.go
@@ -322,7 +322,8 @@ func (s *AppResourceScaler) waitForNoProvisioningInProcess(ctx context.Context) 
 			s.logger.DebugWithCtx(ctx, "Checking the state of the Iguazio tenant app service sets")
 			_, _, state, err := s.getIguazioTenantAppServiceSets(ctx)
 			if err != nil {
-				s.logger.WarnWithCtx(ctx, "Failed to get iguazio tenant app service sets", "err", err)
+				s.logger.WarnWithCtx(ctx, "Failed to get iguazio tenant app service sets",
+					"err", err.Error())
 				continue
 			}
 
@@ -330,7 +331,8 @@ func (s *AppResourceScaler) waitForNoProvisioningInProcess(ctx context.Context) 
 				if finiteStateDiscoveryTime == nil {
 					now := time.Now()
 					finiteStateDiscoveryTime = &now
-					s.logger.DebugWithCtx(ctx, "IguazioTenantAppServiceSet finished provisioning", "state", state)
+					s.logger.DebugWithCtx(ctx,
+						"IguazioTenantAppServiceSet finished provisioning", "state", state)
 				}
 			} else {
 
@@ -339,7 +341,7 @@ func (s *AppResourceScaler) waitForNoProvisioningInProcess(ctx context.Context) 
 					s.logger.DebugWithCtx(ctx, "IguazioTenantAppServiceSet is provisioning again, "+
 						"resetting discovery time",
 						"state", state,
-						"finiteStateDiscoveryTime", finiteStateDiscoveryTime)
+						"finiteStateDiscoveryTime", time.Since(*finiteStateDiscoveryTime).String())
 				}
 				finiteStateDiscoveryTime = nil
 			}
@@ -357,7 +359,7 @@ func (s *AppResourceScaler) waitForNoProvisioningInProcess(ctx context.Context) 
 				}
 				s.logger.DebugWithCtx(ctx, "IguazioTenantAppServiceSet waiting for the state to be stable",
 					"state", state,
-					"timeSince", timeSince)
+					"timeSince", timeSince.String())
 			} else {
 				s.logger.DebugWithCtx(ctx, "IguazioTenantAppServiceSet is still provisioning",
 					"state", state)

--- a/pkg/resourcescaler/resourcescaler.go
+++ b/pkg/resourcescaler/resourcescaler.go
@@ -322,18 +322,22 @@ func (s *AppResourceScaler) waitForNoProvisioningInProcess(ctx context.Context) 
 			s.logger.DebugWithCtx(ctx, "Checking the state of the Iguazio tenant app service sets")
 			_, _, state, err := s.getIguazioTenantAppServiceSets(ctx)
 			if err != nil {
-				return errors.Wrap(err, "Failed to get iguazio tenant app service sets")
+				s.logger.ErrorWithCtx(ctx, "Failed to get iguazio tenant app service sets")
+				continue
 			}
 
 			if state == "ready" || state == "error" {
 				if finiteStateDiscoveryTime == nil {
 					now := time.Now()
 					finiteStateDiscoveryTime = &now
-					s.logger.DebugWithCtx(ctx, "IguazioTenantAppServiceSet finished provisioning")
+					s.logger.DebugWithCtx(ctx, "IguazioTenantAppServiceSet finished provisioning", "state", state)
 				}
 			} else {
 
 				// reset the time if the state is not stable
+				if finiteStateDiscoveryTime != nil {
+					s.logger.DebugWithCtx(ctx, "IguazioTenantAppServiceSet is provisioning again, resetting discovery time", "state", state, "finiteStateDiscoveryTime", finiteStateDiscoveryTime)
+				}
 				finiteStateDiscoveryTime = nil
 			}
 

--- a/pkg/resourcescaler/resourcescaler.go
+++ b/pkg/resourcescaler/resourcescaler.go
@@ -318,7 +318,8 @@ func (s *AppResourceScaler) waitForNoProvisioningInProcess(ctx context.Context) 
 		case <-ctx.Done():
 			return ctx.Err()
 
-		case <-time.After(1 * time.Second):
+		case <-time.After(5 * time.Second):
+			s.logger.DebugWithCtx(ctx, "Checking the state of the Iguazio tenant app service sets")
 			_, _, state, err := s.getIguazioTenantAppServiceSets(ctx)
 			if err != nil {
 				return errors.Wrap(err, "Failed to get iguazio tenant app service sets")


### PR DESCRIPTION
There is a race condition when apply services with bad app service configuration and app service that need to scale to zero.
To fix we make scale to zero wait 30 seconds before scaling to/from zero.

https://iguazio.atlassian.net/browse/IG-22733

<img width="1268" alt="image" src="https://github.com/v3io/app-resource-scaler/assets/107995850/7f360ca2-4d83-4d7e-baa1-af3e93ceb343">

